### PR TITLE
Enabled buffering to stream write, QPS up x10.

### DIFF
--- a/bidi/bidi_stream_perftest.cc
+++ b/bidi/bidi_stream_perftest.cc
@@ -65,6 +65,8 @@ int main(int argc, char** argv) {
   test_bidi_stream::Req req;
   req.set_s(input);
 
+  auto wo = grpc::WriteOptions().set_buffer_hint();
+
   uint64_t id = FLAGS_base_id;
   for (uint64_t iteration = 0u; iteration < SAVE_n; ++iteration) {
     req.set_id(id++);
@@ -77,7 +79,7 @@ int main(int argc, char** argv) {
     req.set_c(c);
     req.set_n(n);
 
-    stream->Write(req);
+    stream->Write(req, wo);
   }
 
   stream->WritesDone();

--- a/bidi/bidi_stream_server.cc
+++ b/bidi/bidi_stream_server.cc
@@ -22,6 +22,7 @@ int main(int argc, char** argv) {
 
       test_bidi_stream::Req req;
       test_bidi_stream::Res res;
+      auto wo = grpc::WriteOptions().set_buffer_hint();
 
       while (stream->Read(&req)) {
         std::string s = req.s();
@@ -48,7 +49,7 @@ int main(int argc, char** argv) {
           }
           res.set_r(os.str());
         }
-        stream->Write(res);
+        stream->Write(res, wo);
       }
 
       std::cerr << "Closing a stream." << std::endl;


### PR DESCRIPTION
Added write stream buffering as suggested [here](https://grpc.io/docs/guides/performance/)
> (Special topic) Enable write batching in streams if message k + 1 does not rely on responses from message k by passing a WriteOptions argument to Write with buffer_hint set:
stream_writer->Write(message, WriteOptions().set_buffer_hint());

Perftest went up from 25k to 280k on my machine (in release mode).
